### PR TITLE
Fix problem with `Gemfile` due to deprecation of `:rubygems`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'http://rubygems.org/'
 
 gem 'activesupport'
 gem 'compass'


### PR DESCRIPTION
With the current version of Stoplight you get a warning from bundler:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```

This pull request prevents this warning by changing the `source` in the `Gemfile` to "https://rubygems.org"
